### PR TITLE
Update for redis-py ver 3+ compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     keywords             = 'Redis, queue, data structures',
     license              = 'MIT',
     packages             = find_packages(),
-    install_requires     = ['future', 'redis'],
+    install_requires     = ['future', 'redis>=3.0.0'],
     py_modules           = ['qr'],
     include_package_data = True,
     zip_safe             = False,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-version = '1.0.0'
+version = '1.0.1'
 
 LONG_DESCRIPTION = '''
 


### PR DESCRIPTION
Some of the syntax for redis-py changed from v2 -> v3. Check out he [readme](https://github.com/andymccurdy/redis-py) for more information.

I added the [packaging](https://github.com/pypa/packaging) dependency and a conditional that will apply the correct syntax for the `zadd` method, which is used in two locations in the code.